### PR TITLE
Add function to list 'subfolders' in a GCS bucket path

### DIFF
--- a/proc_gcs_utils/gcs.py
+++ b/proc_gcs_utils/gcs.py
@@ -82,7 +82,7 @@ def list_bucket_contents(gcp_project_name: str,
                          gcs_bucket_name: str,
                          gcs_bucket_path: str,
                          recurse: bool=False) -> HTTPIterator:
-    """List the contents of a Google Cloud Storage bucket
+    """List the blobs in a Google Cloud Storage bucket
 
     Args:
       gcp_project_name (str): the Google Cloud Project name
@@ -105,7 +105,7 @@ def list_bucket_contents(gcp_project_name: str,
 
 def list_bucket_folders(gcp_project_name: str,
                         gcs_bucket_name: str,
-                        gcs_bucket_path: str) -> set:
+                        gcs_bucket_path: str) -> list:
     """List the 'folders' in a Google Cloud Storage bucket path
 
     Args:
@@ -113,7 +113,7 @@ def list_bucket_folders(gcp_project_name: str,
       gcs_bucket_name (str): the Google Cloud Storage bucket name
       gcs_bucket_path (str): the storage path in the bucket
 
-    Returns a set of strings
+    Returns a list of strings
     """
     folders = set()
     prefix_length = len(gcs_bucket_path.split('/'))
@@ -125,7 +125,7 @@ def list_bucket_folders(gcp_project_name: str,
         if len(blob_path_segments) > prefix_length + 1:
             folders.add(blob.name.split('/')[prefix_length])
 
-    return folders
+    return list(folders)
 
 
 def download_files_from_gcs(gcp_project_name: str,

--- a/proc_gcs_utils/tests/test_gcs.py
+++ b/proc_gcs_utils/tests/test_gcs.py
@@ -84,7 +84,7 @@ def test_gcs_bucket_upload_download():
                                               GCS_BUCKET_NAME,
                                               GCS_BUCKET_PATH)
 
-            assert folders == {TOO_DEEP_FOLDER_NAME}
+            assert folders == [TOO_DEEP_FOLDER_NAME]
 
             # Verify we can download the test files
             output_dir = os.path.join(temp_path, 'out')


### PR DESCRIPTION
Resolves https://vulcan.atlassian.net/browse/CA-613

Also:
1. Renamd "forbidden" to "too_deep" to reflect the purpose of those test objects.
2. Moved the `try` block higher to catch (and clean up) errors earlier in the test, so some changes reflect only indentation.